### PR TITLE
Add check that attendee has updated their namespace

### DIFF
--- a/enroll.sh
+++ b/enroll.sh
@@ -2,13 +2,16 @@
 
 set -e
 
-TOKEN=$1
 
+# Replace 'your)namespace' with the namespace provided by the organiser for this workshop.
+USERNAME=your_namespace
+if [ "$USERNAME" == "your_namespace"  ]; then echo "You need to edit enroll.sh to set your namespace"; exit -1; fi
+
+TOKEN=$1
 if [ "$TOKEN" == ""  ]; then echo "Require token."; exit -1; fi
 
 CLUSTER_NAME=library.yun.technology
 NICKNAME=library
-USERNAME=your_namespace
 MASTER_LOAD_BALANCER=library.yun.technology
 
 MASTERCRT="-----BEGIN CERTIFICATE-----


### PR DESCRIPTION
Hi @harryleesan 

Great workshop!

As I was working through the workshop the first time, I missed that I needed to update the `USERNAME` variable in `enroll.sh` resulting in a *your_namespace* user being created.

This PR adds a check the bails out of the script if this mistake is made by someone else